### PR TITLE
getChildOfType negative indices: size_t is unsigned

### DIFF
--- a/loader/include/Geode/utils/cocos.hpp
+++ b/loader/include/Geode/utils/cocos.hpp
@@ -611,6 +611,7 @@ namespace geode::cocos {
                     }
                     ++indexCounter;
                 }
+                if (i == 0) break;
             }
         }
         else {


### PR DESCRIPTION
`i` is always >= 0 because it is unsigned. This causes crashes if no children are found before reaching 0.